### PR TITLE
add fixtures from the thrift library

### DIFF
--- a/tests/fixtures/AnnotationTest.thrift
+++ b/tests/fixtures/AnnotationTest.thrift
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+typedef list<i32> ( cpp.template = "std::list" ) int_linked_list
+
+struct foo {
+  1: i32 bar ( presence = "required" );
+  2: i32 baz ( presence = "manual", cpp.use_pointer = "", );
+  3: i32 qux;
+  4: i32 bop;
+} (
+  cpp.type = "DenseFoo",
+  python.type = "DenseFoo",
+  java.final = "",
+  annotation.without.value,
+)
+
+exception foo_error {
+  1: i32 error_code ( foo="bar" )
+  2: string error_msg
+} (foo = "bar")
+
+typedef string ( unicode.encoding = "UTF-16" ) non_latin_string (foo="bar")
+typedef list< double ( cpp.fixed_point = "16" ) > tiny_float_list
+
+enum weekdays {
+  SUNDAY ( weekend = "yes" ),
+  MONDAY,
+  TUESDAY,
+  WEDNESDAY,
+  THURSDAY,
+  FRIDAY,
+  SATURDAY ( weekend = "yes" )
+} (foo.bar="baz")
+
+/* Note that annotations on senum values are not supported. */
+senum seasons {
+  "Spring",
+  "Summer",
+  "Fall",
+  "Winter"
+} ( foo = "bar" )
+
+service foo_service {
+  void foo() ( foo = "bar" )
+} (a.b="c")
+

--- a/tests/fixtures/BrokenConstants.thrift
+++ b/tests/fixtures/BrokenConstants.thrift
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const i64 myint = 68719476736
+const i64 broken = 9876543210987654321  // A little over 2^63
+
+enum foo {
+  bar = 68719476736
+}

--- a/tests/fixtures/ConstantsDemo.thrift
+++ b/tests/fixtures/ConstantsDemo.thrift
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace cpp yozone
+
+struct thing {
+  1: i32 hello,
+  2: i32 goodbye
+}
+
+enum enumconstants {
+  ONE = 1,
+  TWO = 2
+}
+
+// struct thing2 {
+//   /** standard docstring */
+//   1: enumconstants val = TWO
+// }
+
+typedef i32 myIntType
+const myIntType myInt = 3
+
+//const map<enumconstants,string> GEN_ENUM_NAMES = {ONE : "HOWDY", TWO: "PARTNER"}
+
+/* not supported by thrift-parser
+const i32 hex_const = 0x0001F
+const i32 negative_hex_constant = -0x0001F
+*/
+
+const i32 GEN_ME = -3523553
+const double GEn_DUB = 325.532
+const double GEn_DU = 085.2355
+const string GEN_STRING = "asldkjasfd"
+
+/* not supported by thrift-parser
+const double e10 = 1e10   // fails with 0.9.3 and earlier
+const double e11 = -1e10
+*/
+
+const map<i32,i32> GEN_MAP = { 35532 : 233, 43523 : 853 }
+const list<i32> GEN_LIST = [ 235235, 23598352, 3253523 ]
+
+const map<i32, map<i32, i32>> GEN_MAPMAP = { 235 : { 532 : 53255, 235:235}}
+
+const map<string,i32> GEN_MAP2 = { "hello" : 233, "lkj98d" : 853, 'lkjsdf' : 098325 }
+
+const thing GEN_THING = { 'hello' : 325, 'goodbye' : 325352 }
+
+const map<i32,thing> GEN_WHAT = { 35 : { 'hello' : 325, 'goodbye' : 325352 } }
+
+const set<i32> GEN_SET = [ 235, 235, 53235 ]
+
+exception Blah {
+  1:  i32 bing }
+
+exception Gak {}
+
+service yowza {
+  void blingity(),
+  i32 blangity() throws (1: Blah hoot )
+}

--- a/tests/fixtures/DebugProtoTest.thrift
+++ b/tests/fixtures/DebugProtoTest.thrift
@@ -1,0 +1,378 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace c_glib TTest
+namespace cpp thrift.test.debug
+namespace java thrift.test
+namespace rb thrift.test
+
+struct Doubles {
+ 1: double nan,
+ 2: double inf,
+ 3: double neginf,
+ 4: double repeating,
+ 5: double big,
+ 6: double tiny,
+ 7: double zero,
+ 8: double negzero,
+}
+
+struct OneOfEach {
+  1: bool im_true,
+  2: bool im_false,
+  3: i8 a_bite = 0x7f,
+  4: i16 integer16 = 0x7fff,
+  5: i32 integer32,
+  6: i64 integer64 = 10000000000,
+  7: double double_precision,
+  8: string some_characters,
+  9: string zomg_unicode,
+  10: bool what_who,
+  11: binary base64,
+  12: list<i8> byte_list = [1, 2, 3],
+  13: list<i16> i16_list = [1,2,3],
+  14: list<i64> i64_list = [1,2,3]
+}
+
+struct Bonk {
+  1: i32 type,
+  2: string message,
+}
+
+struct Nesting {
+  1: Bonk my_bonk,
+  2: OneOfEach my_ooe,
+}
+
+struct HolyMoley {
+  1: list<OneOfEach> big,
+  2: set<list<string> (python.immutable = "")> contain,
+  3: map<string,list<Bonk>> bonks,
+}
+
+struct Backwards {
+  2: i32 first_tag2,
+  1: i32 second_tag1,
+}
+
+struct Empty {
+} (
+  python.immutable = "",
+)
+
+struct Wrapper {
+  1: Empty foo
+} (
+  python.immutable = "",
+)
+
+struct RandomStuff {
+  1: i32 a,
+  2: i32 b,
+  3: i32 c,
+  4: i32 d,
+  5: list<i32> myintlist,
+  6: map<i32,Wrapper> maps,
+  7: i64 bigint,
+  8: double triple,
+}
+
+struct Base64 {
+  1: i32 a,
+  2: binary b1,
+  3: binary b2,
+  4: binary b3,
+  5: binary b4,
+  6: binary b5,
+  7: binary b6,
+}
+
+struct CompactProtoTestStruct {
+  // primitive fields
+  1: i8     a_byte;
+  2: i16    a_i16;
+  3: i32    a_i32;
+  4: i64    a_i64;
+  5: double a_double;
+  6: string a_string;
+  7: binary a_binary;
+  8: bool   true_field;
+  9: bool   false_field;
+  10: Empty empty_struct_field;
+
+  // primitives in lists
+  11: list<i8>      byte_list;
+  12: list<i16>     i16_list;
+  13: list<i32>     i32_list;
+  14: list<i64>     i64_list;
+  15: list<double>  double_list;
+  16: list<string>  string_list;
+  17: list<binary>  binary_list;
+  18: list<bool>    boolean_list;
+  19: list<Empty>   struct_list;
+
+  // primitives in sets
+  20: set<i8>       byte_set;
+  21: set<i16>      i16_set;
+  22: set<i32>      i32_set;
+  23: set<i64>      i64_set;
+  24: set<double>   double_set;
+  25: set<string>   string_set;
+  26: set<binary>   binary_set;
+  27: set<bool>     boolean_set;
+  28: set<Empty>    struct_set;
+
+  // maps
+  // primitives as keys
+  29: map<i8, i8>               byte_byte_map;
+  30: map<i16, i8>              i16_byte_map;
+  31: map<i32, i8>              i32_byte_map;
+  32: map<i64, i8>              i64_byte_map;
+  33: map<double, i8>           double_byte_map;
+  34: map<string, i8>           string_byte_map;
+  35: map<binary, i8>           binary_byte_map;
+  36: map<bool, i8>             boolean_byte_map;
+  // primitives as values
+  37: map<i8, i16>              byte_i16_map;
+  38: map<i8, i32>              byte_i32_map;
+  39: map<i8, i64>              byte_i64_map;
+  40: map<i8, double>           byte_double_map;
+  41: map<i8, string>           byte_string_map;
+  42: map<i8, binary>           byte_binary_map;
+  43: map<i8, bool>             byte_boolean_map;
+  // collections as keys
+  44: map<list<i8> (python.immutable = ""), i8>       list_byte_map;
+  45: map<set<i8> (python.immutable = ""), i8>        set_byte_map;
+  46: map<map<i8,i8> (python.immutable = ""), i8>     map_byte_map;
+  // collections as values
+  47: map<i8, map<i8,i8>>     byte_map_map;
+  48: map<i8, set<i8>>        byte_set_map;
+  49: map<i8, list<i8>>       byte_list_map;
+}
+
+// To be used to test the serialization of an empty map
+struct SingleMapTestStruct {
+  1: required map<i32, i32>       i32_map;
+}
+
+const CompactProtoTestStruct COMPACT_TEST = {
+  'a_byte'             : 127,
+  'a_i16'              : 32000,
+  'a_i32'              : 1000000000,
+  'a_i64'              : 0xffffffffff,
+  'a_double'           : 5.6789,
+  'a_string'           : "my string",
+//'a_binary,'
+  'true_field'         : 1,
+  'false_field'        : 0,
+  'empty_struct_field' : {},
+  'byte_list'          : [-127, -1, 0, 1, 127],
+  'i16_list'           : [-1, 0, 1, 0x7fff],
+  'i32_list'           : [-1, 0, 0xff, 0xffff, 0xffffff, 0x7fffffff],
+  'i64_list'           : [-1, 0, 0xff, 0xffff, 0xffffff, 0xffffffff, 0xffffffffff, 0xffffffffffff, 0xffffffffffffff, 0x7fffffffffffffff],
+  'double_list'        : [0.1, 0.2, 0.3],
+  'string_list'        : ["first", "second", "third"],
+//'binary_list,'
+  'boolean_list'       : [1, 1, 1, 0, 0, 0],
+  'struct_list'        : [{}, {}],
+  'byte_set'           : [-127, -1, 0, 1, 127],
+  'i16_set'            : [-1, 0, 1, 0x7fff],
+  'i32_set'            : [1, 2, 3],
+  'i64_set'            : [-1, 0, 0xff, 0xffff, 0xffffff, 0xffffffff, 0xffffffffff, 0xffffffffffff, 0xffffffffffffff, 0x7fffffffffffffff],
+  'double_set'         : [0.1, 0.2, 0.3],
+  'string_set'         : ["first", "second", "third"],
+//'binary_set,'
+  'boolean_set'        : [1, 0],
+  'struct_set'         : [{}],
+  'byte_byte_map'      : {1 : 2},
+  'i16_byte_map'       : {1 : 1, -1 : 1, 0x7fff : 1},
+  'i32_byte_map'       : {1 : 1, -1 : 1, 0x7fffffff : 1},
+  'i64_byte_map'       : {0 : 1,  1 : 1, -1 : 1, 0x7fffffffffffffff : 1},
+  'double_byte_map'    : {-1.1 : 1, 1.1 : 1},
+  'string_byte_map'    : {"first" : 1, "second" : 2, "third" : 3, "" : 0},
+//'binary_byte_map,'
+  'boolean_byte_map'   : {1 : 1, 0 : 0},
+  'byte_i16_map'       : {1 : 1, 2 : -1, 3 : 0x7fff},
+  'byte_i32_map'       : {1 : 1, 2 : -1, 3 : 0x7fffffff},
+  'byte_i64_map'       : {1 : 1, 2 : -1, 3 : 0x7fffffffffffffff},
+  'byte_double_map'    : {1 : 0.1, 2 : -0.1, 3 : 1000000.1},
+  'byte_string_map'    : {1 : "", 2 : "blah", 3 : "loooooooooooooong string"},
+//'byte_binary_map,'
+  'byte_boolean_map'   : {1 : 1, 2 : 0},
+  'list_byte_map'      : {[1, 2, 3] : 1, [0, 1] : 2, [] : 0},
+  'set_byte_map'       : {[1, 2, 3] : 1, [0, 1] : 2, [] : 0},
+  'map_byte_map'       : {{1 : 1} : 1, {2 : 2} : 2, {} : 0},
+  'byte_map_map'       : {0 : {}, 1 : {1 : 1}, 2 : {1 : 1, 2 : 2}},
+  'byte_set_map'       : {0 : [], 1 : [1], 2 : [1, 2]},
+  'byte_list_map'      : {0 : [], 1 : [1], 2 : [1, 2]},
+}
+
+
+const i32 MYCONST = 2
+
+
+exception ExceptionWithAMap {
+  1: string blah;
+  2: map<string, string> map_field;
+}
+
+service ServiceForExceptionWithAMap {
+  void methodThatThrowsAnException() throws (1: ExceptionWithAMap xwamap);
+}
+
+service Srv {
+  i32 Janky(1: i32 arg);
+
+  // return type only methods
+
+  void voidMethod();
+  i32 primitiveMethod();
+  CompactProtoTestStruct structMethod();
+
+  void methodWithDefaultArgs(1: i32 something = MYCONST);
+
+  oneway void onewayMethod();
+
+  bool declaredExceptionMethod(1: bool shouldThrow) throws (1: ExceptionWithAMap xwamap);
+}
+
+service Inherited extends Srv {
+  i32 identity(1: i32 arg)
+}
+
+service EmptyService {}
+
+// The only purpose of this thing is to increase the size of the generated code
+// so that ZlibTest has more highly compressible data to play with.
+struct BlowUp {
+  1: map<list<i32>(python.immutable = ""),set<map<i32,string> (python.immutable = "")>> b1;
+  2: map<list<i32>(python.immutable = ""),set<map<i32,string> (python.immutable = "")>> b2;
+  3: map<list<i32>(python.immutable = ""),set<map<i32,string> (python.immutable = "")>> b3;
+  4: map<list<i32>(python.immutable = ""),set<map<i32,string> (python.immutable = "")>> b4;
+}
+
+
+struct ReverseOrderStruct {
+  4: string first;
+  3: i16 second;
+  2: i32 third;
+  1: i64 fourth;
+}
+
+service ReverseOrderService {
+  void myMethod(4: string first, 3: i16 second, 2: i32 third, 1: i64 fourth);
+}
+
+enum SomeEnum {
+  ONE = 1
+  TWO = 2
+}
+
+/** This is a docstring on a constant! */
+const SomeEnum MY_SOME_ENUM = SomeEnum.ONE
+
+const SomeEnum MY_SOME_ENUM_1 = 1
+/*const SomeEnum MY_SOME_ENUM_2 = 7*/
+
+const map<SomeEnum,SomeEnum> MY_ENUM_MAP = {
+  SomeEnum.ONE : SomeEnum.TWO
+}
+
+struct StructWithSomeEnum {
+  1: SomeEnum blah;
+}
+
+const map<SomeEnum,StructWithSomeEnum> EXTRA_CRAZY_MAP = {
+  SomeEnum.ONE : {"blah" : SomeEnum.TWO}
+}
+
+union TestUnion {
+  /**
+   * A doc string
+   */
+  1: string string_field;
+  2: i32 i32_field;
+  3: OneOfEach struct_field;
+  4: list<RandomStuff> struct_list;
+  5: i32 other_i32_field;
+  6: SomeEnum enum_field;
+  7: set<i32> i32_set;
+  8: map<i32, i32> i32_map;
+}
+
+union TestUnionMinusStringField {
+  2: i32 i32_field;
+  3: OneOfEach struct_field;
+  4: list<RandomStuff> struct_list;
+  5: i32 other_i32_field;
+  6: SomeEnum enum_field;
+  7: set<i32> i32_set;
+  8: map<i32, i32> i32_map;
+}
+
+union ComparableUnion {
+  1: string string_field;
+  2: binary binary_field;
+}
+
+struct StructWithAUnion {
+  1: TestUnion test_union;
+}
+
+struct PrimitiveThenStruct {
+  1: i32 blah;
+  2: i32 blah2;
+  3: Backwards bw;
+}
+
+typedef map<i32,i32> SomeMap
+
+struct StructWithASomemap {
+  1: required SomeMap somemap_field;
+}
+
+struct BigFieldIdStruct {
+  1: string field1;
+  45: string field2;
+}
+
+struct BreaksRubyCompactProtocol {
+  1: string field1;
+  2: BigFieldIdStruct field2;
+  3: i32 field3;
+}
+
+struct TupleProtocolTestStruct {
+  optional i32 field1;
+  optional i32 field2;
+  optional i32 field3;
+  optional i32 field4;
+  optional i32 field5;
+  optional i32 field6;
+  optional i32 field7;
+  optional i32 field8;
+  optional i32 field9;
+  optional i32 field10;
+  optional i32 field11;
+  optional i32 field12;
+}
+
+struct ListDoublePerf {
+  1: list<double> field;
+}

--- a/tests/fixtures/DenseLinkingTest.thrift
+++ b/tests/fixtures/DenseLinkingTest.thrift
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+../compiler/cpp/thrift -gen cpp:dense DebugProtoTest.thrift
+../compiler/cpp/thrift -gen cpp:dense DenseLinkingTest.thrift
+g++ -Wall -g -I../lib/cpp/src -I/usr/local/include/boost-1_33_1 \
+  DebugProtoTest.cpp gen-cpp/DebugProtoTest_types.cpp \
+  gen-cpp/DenseLinkingTest_types.cpp \
+  ../lib/cpp/.libs/libthrift.a -o DebugProtoTest
+./DebugProtoTest
+*/
+
+/*
+The idea of this test is that everything is structurally identical to DebugProtoTest.
+If I messed up the naming of the reflection local typespecs,
+then compiling this should give errors because of doubly defined symbols.
+*/
+
+namespace cpp thrift.test
+namespace java thrift.test
+
+struct OneOfEachZZ {
+  1: bool im_true,
+  2: bool im_false,
+  3: byte a_bite,
+  4: i16 integer16,
+  5: i32 integer32,
+  6: i64 integer64,
+  7: double double_precision,
+  8: string some_characters,
+  9: string zomg_unicode,
+  10: bool what_who,
+}
+
+struct BonkZZ {
+  1: i32 type,
+  2: string message,
+}
+
+struct NestingZZ {
+  1: BonkZZ my_bonk,
+  2: OneOfEachZZ my_ooe,
+}
+
+struct HolyMoleyZZ {
+  1: list<OneOfEachZZ> big,
+  2: set<list<string>> contain,
+  3: map<string,list<BonkZZ>> bonks,
+}
+
+struct BackwardsZZ {
+  2: i32 first_tag2,
+  1: i32 second_tag1,
+}
+
+struct EmptyZZ {
+}
+
+struct WrapperZZ {
+  1: EmptyZZ foo
+}
+
+struct RandomStuffZZ {
+  1: i32 a,
+  2: i32 b,
+  3: i32 c,
+  4: i32 d,
+  5: list<i32> myintlist,
+  6: map<i32,WrapperZZ> maps,
+  7: i64 bigint,
+  8: double triple,
+}
+
+service Srv {
+  i32 Janky(1: i32 arg)
+}
+
+service UnderscoreSrv {
+  i64 some_rpc_call(1: string message)
+}
+

--- a/tests/fixtures/DocTest.thrift
+++ b/tests/fixtures/DocTest.thrift
@@ -1,0 +1,287 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Program doctext.
+ *
+ * Seriously, this is the documentation for this whole program.
+ */
+
+namespace java thrift.test
+namespace cpp thrift.test
+
+// C++ comment
+/* c style comment */
+
+# the new unix comment
+
+/** Some doc text goes here.  Wow I am [nesting these] (no more nesting.) */
+enum Numberz
+{
+
+  /** This is how to document a parameter */
+  ONE = 1,
+
+  /** And this is a doc for a parameter that has no specific value assigned */
+  TWO,
+
+  THREE,
+  FIVE = 5,
+  SIX,
+  EIGHT = 8
+}
+
+/** This is how you would do a typedef doc */
+typedef i64 UserId
+
+/** And this is where you would document a struct */
+struct Xtruct
+{
+
+  /** And the members of a struct */
+  1:  string string_thing
+
+  /** doct text goes before a comma */
+  4:  i8     byte_thing,
+
+  9:  i32    i32_thing,
+  11: i64    i64_thing
+}
+
+/**
+ * You can document constants now too.  Yeehaw!
+ */
+const i32 INT32CONSTANT = 9853
+const i16 INT16CONSTANT = 1616
+/** Everyone get in on the docu-action! */
+const map<string,string> MAPCONSTANT = {'hello':'world', 'goodnight':'moon'}
+
+struct Xtruct2
+{
+  1: i8     byte_thing,
+  2: Xtruct struct_thing,
+  3: i32    i32_thing
+}
+
+/** Struct insanity */
+struct Insanity
+{
+
+  /** This is doc for field 1 */
+  1: map<Numberz, UserId> userMap,
+
+  /** And this is doc for field 2 */
+  2: list<Xtruct> xtructs
+}
+
+exception Xception {
+  1: i32 errorCode,
+  2: string message
+}
+
+exception Xception2 {
+  1: i32 errorCode,
+  2: Xtruct struct_thing
+}
+
+/* C1 */
+/** Doc */
+/* C2 */
+/* C3 */
+struct EmptyStruct {}
+
+struct OneField {
+  1: EmptyStruct field
+}
+
+/** This is where you would document a Service */
+service ThriftTest
+{
+
+  /** And this is how you would document functions in a service */
+  void         testVoid(),
+  string       testString(1: string thing),
+  i8           testByte(1: byte thing),
+  i32          testI32(1: i32 thing),
+
+  /** Like this one */
+  i64          testI64(1: i64 thing),
+  double       testDouble(1: double thing),
+  Xtruct       testStruct(1: Xtruct thing),
+  Xtruct2      testNest(1: Xtruct2 thing),
+  map<i32,i32> testMap(1: map<i32,i32> thing),
+  set<i32>     testSet(1: set<i32> thing),
+  list<i32>    testList(1: list<i32> thing),
+
+  /** This is an example of a function with params documented */
+  Numberz      testEnum(
+
+    /** This param is a thing */
+    1: Numberz thing
+
+  ),
+
+  UserId       testTypedef(1: UserId thing),
+
+  map<i32,map<i32,i32>> testMapMap(1: i32 hello),
+
+  /* So you think you've got this all worked, out eh? */
+  map<UserId, map<Numberz,Insanity>> testInsanity(1: Insanity argument),
+
+}
+
+/// This style of Doxy-comment doesn't work.
+typedef i32 SorryNoGo
+
+/**
+ * This is a trivial example of a multiline docstring.
+ */
+typedef i32 TrivialMultiLine
+
+/**
+ * This is the canonical example
+ * of a multiline docstring.
+ */
+typedef i32 StandardMultiLine
+
+/**
+ * The last line is non-blank.
+ * I said non-blank! */
+typedef i32 LastLine
+
+/** Both the first line
+ * are non blank. ;-)
+ * and the last line */
+typedef i32 FirstAndLastLine
+
+/**
+ *    INDENTED TITLE
+ * The text is less indented.
+ */
+typedef i32 IndentedTitle
+
+/**       First line indented.
+ * Unfortunately, this does not get indented.
+ */
+typedef i32 FirstLineIndent
+
+
+/**
+ * void code_in_comment() {
+ *   printf("hooray code!");
+ * }
+ */
+typedef i32 CodeInComment
+
+    /**
+     * Indented Docstring.
+     * This whole docstring is indented.
+     *   This line is indented further.
+     */
+typedef i32 IndentedDocstring
+
+/** Irregular docstring.
+ * We will have to punt
+  * on this thing */
+typedef i32 Irregular1
+
+/**
+ * note the space
+ * before these lines
+* but not this
+ * one
+ */
+typedef i32 Irregular2
+
+/**
+* Flush against
+* the left.
+*/
+typedef i32 Flush
+
+/**
+  No stars in this one.
+  It should still work fine, though.
+    Including indenting.
+    */
+typedef i32 NoStars
+
+/** Trailing whitespace   
+Sloppy trailing whitespace   
+is truncated.   */
+typedef i32 TrailingWhitespace
+
+/**
+ * This is a big one.
+ *
+ * We'll have some blank lines in it.
+ * 
+ * void as_well_as(some code) {
+ *   puts("YEEHAW!");
+ * }
+ */
+typedef i32 BigDog
+
+/**
+*
+*
+*/
+typedef i32 TotallyDegenerate
+
+/**no room for newline here*/
+
+/* * / */
+typedef i32 TestFor3501a
+
+/**
+ * /
+ */
+typedef i32 TestFor3501b
+
+
+/* Comment-end tokens can of course have more than one asterisk */
+struct TestFor3709_00 { /* ? */ 1: i32 foo }
+/* Comment-end tokens can of course have more than one asterisk **/
+struct TestFor3709_01 { /* ? */ 1: i32 foo }
+/* Comment-end tokens can of course have more than one asterisk ***/
+struct TestFor3709_02 { /* ? */ 1: i32 foo }
+/** Comment-end tokens can of course have more than one asterisk */
+struct TestFor3709_03 { /* ? */ 1: i32 foo }
+/** Comment-end tokens can of course have more than one asterisk **/
+struct TestFor3709_04 { /* ? */ 1: i32 foo }
+/** Comment-end tokens can of course have more than one asterisk ***/
+struct TestFor3709_05 { /* ? */ 1: i32 foo }
+/*** Comment-end tokens can of course have more than one asterisk */
+struct TestFor3709_06 { /* ? */ 1: i32 foo }
+/*** Comment-end tokens can of course have more than one asterisk **/
+struct TestFor3709_07 { /* ? */ 1: i32 foo }
+/*** Comment-end tokens can of course have more than one asterisk ***/
+struct TestFor3709_08 { /* ? */ 1: i32 foo }
+
+struct TestFor3709 {
+  /** This is a comment */
+  1: required string id,
+  /** This is also a comment **/
+  2: required string typeId,
+  /** Yet another comment! */
+  3: required i32 endTimestamp
+}
+
+
+/* THE END */

--- a/tests/fixtures/EnumTest.thrift
+++ b/tests/fixtures/EnumTest.thrift
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Contains some contributions under the Thrift Software License.
+ * Please see doc/old-thrift-license.txt in the Thrift distribution for
+ * details.
+ */
+
+namespace c_glib TTest
+
+enum MyEnum1 {
+  ME1_0 = 0,
+  ME1_1 = 1,
+  ME1_2,
+  ME1_3,
+  ME1_5 = 5,
+  ME1_6,
+}
+
+enum MyEnum2 {
+  ME2_0,
+  ME2_1,
+  ME2_2,
+}
+
+enum MyEnum2_again {
+  // enum value identifiers may appear again in another enum type
+  ME0_1,
+  ME1_1,
+  ME2_1,
+  ME3_1,
+}
+
+enum MyEnum3 {
+  ME3_0,
+  ME3_1,
+  ME3_N2 = -2,
+  ME3_N1,
+  ME3_D0,
+  ME3_D1,
+  ME3_9 = 9,
+  ME3_10,
+}
+
+enum MyEnum4 {
+  ME4_A = 0x7ffffffd
+  ME4_B
+  ME4_C
+  // attempting to define another enum value here fails
+  // with an overflow error, as we overflow values that can be
+  // represented with an i32.
+}
+
+enum MyEnum5 {
+  e1        // fails with 0.9.3 and earlier
+  e2 = 42   // fails with 0.9.3 and earlier
+}
+
+struct MyStruct {
+  1: MyEnum2 me2_2 = MyEnum1.ME2_2
+  2: MyEnum3 me3_n2 = MyEnum3.ME3_N2
+  3: MyEnum3 me3_d1 = MyEnum3.ME3_D1
+}
+
+struct EnumTestStruct {
+  1: MyEnum3 a_enum;
+  2: list<MyEnum3> enum_list;
+  3: set<MyEnum3> enum_set;
+  4: map<MyEnum3, MyEnum3> enum_enum_map;
+  // collections as keys
+  /* not supported by thrift-parser
+  44: map<list<MyEnum3> (python.immutable = ""), MyEnum3> list_enum_map;
+  45: map<set<MyEnum3> (python.immutable = ""), MyEnum3> set_enum_map;
+  46: map<map<MyEnum3,MyEnum3> (python.immutable = ""), MyEnum3> map_enum_map;
+  */
+  // collections as values
+  47: map<MyEnum3, map<MyEnum3, MyEnum3>> enum_map_map;
+  48: map<MyEnum3, set<MyEnum3>> enum_set_map;
+  49: map<MyEnum3, list<MyEnum3>> enum_list_map;
+}
+
+const EnumTestStruct ENUM_TEST = {
+  'a_enum': MyEnum3.ME3_D1,
+  'enum_list': [MyEnum3.ME3_D1, MyEnum3.ME3_0, MyEnum3.ME3_N2],
+  'enum_set': [MyEnum3.ME3_D1, MyEnum3.ME3_N1],
+  'enum_enum_map': {MyEnum3.ME3_D1: MyEnum3.ME3_0, MyEnum3.ME3_0: MyEnum3.ME3_D1},
+  'list_enum_map': {[MyEnum3.ME3_D1, MyEnum3.ME3_0]: MyEnum3.ME3_0, [MyEnum3.ME3_D1]: MyEnum3.ME3_0, [MyEnum3.ME3_0]: MyEnum3.ME3_D1},
+  'set_enum_map': {[MyEnum3.ME3_D1, MyEnum3.ME3_0]: MyEnum3.ME3_0, [MyEnum3.ME3_D1]: MyEnum3.ME3_0},
+  'map_enum_map': {{MyEnum3.ME3_N1: MyEnum3.ME3_10}: MyEnum3.ME3_1},
+  'enum_map_map': {MyEnum3.ME3_N1: {MyEnum3.ME3_D1: MyEnum3.ME3_D1}},
+  'enum_set_map': {MyEnum3.ME3_N2: [MyEnum3.ME3_D1, MyEnum3.ME3_N1], MyEnum3.ME3_10: [MyEnum3.ME3_D1, MyEnum3.ME3_N1]},
+  'enum_list_map': {MyEnum3.ME3_D1: [MyEnum3.ME3_10], MyEnum3.ME3_0: [MyEnum3.ME3_9, MyEnum3.ME3_10]},
+}
+
+service EnumTestService {
+  MyEnum3 testEnum(1: MyEnum3 enum1),
+  list<MyEnum3> testEnumList(1: list<MyEnum3> enum1),
+  set<MyEnum3> testEnumSet(1: set<MyEnum3> enum1),
+  map<MyEnum3, MyEnum3> testEnumMap(1: map<MyEnum3, MyEnum3> enum1),
+  EnumTestStruct testEnumStruct(1: EnumTestStruct enum1),
+}

--- a/tests/fixtures/FullCamelTest.thrift
+++ b/tests/fixtures/FullCamelTest.thrift
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace java thrift.test.fullcamel
+
+struct OneOfEachZZ {
+  1: bool im_true,
+  2: bool im_false,
+  3: byte a_bite,
+  4: i16 integer16,
+  5: i32 integer32,
+  6: i64 integer64,
+  7: double double_precision,
+  8: string some_characters,
+  9: string zomg_unicode,
+  10: bool what_who,
+}
+
+service UnderscoreSrv {
+  i64 some_rpc_call(1: string message)
+}
+

--- a/tests/fixtures/Include.thrift
+++ b/tests/fixtures/Include.thrift
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+include "ThriftTest.thrift"
+
+struct IncludeTest {
+  1: required ThriftTest.Bools bools
+}

--- a/tests/fixtures/JavaBeansTest.thrift
+++ b/tests/fixtures/JavaBeansTest.thrift
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace java thrift.test
+
+struct OneOfEachBeans {
+  1: bool boolean_field,
+  2: byte a_bite,
+  3: i16 integer16,
+  4: i32 integer32,
+  5: i64 integer64,
+  6: double double_precision,
+  7: string some_characters,
+  8: binary base64,
+  9: list<byte> byte_list,
+  10: list<i16> i16_list,
+  11: list<i64> i64_list
+}
+
+
+service Service {
+  i64 mymethod(i64 blah);
+}

--- a/tests/fixtures/JavaTypes.thrift
+++ b/tests/fixtures/JavaTypes.thrift
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace java thrift.test
+
+struct Integer {
+  1: i32 val
+}
+
+struct String {
+  1: string val
+}
+
+struct Boolean {
+  1: bool val
+}
+
+struct Double {
+  1: double val
+}
+
+struct Long {
+  1: i64 val
+}
+
+struct Byte {
+  1: byte val
+}
+
+struct Float {
+  1: double val
+}
+
+struct List {
+  1: list<string> vals
+}
+
+struct ArrayList {
+  1: list<string> vals
+}
+
+struct SortedMap {
+  1: map<string, string> vals
+}
+
+struct TreeMap {
+  1: map<string, string> vals
+}
+
+struct HashMap {
+  1: map<string, String> vals
+}
+
+struct Map {
+  1: map<double, Double> vals
+}
+
+struct Object {
+  1: Integer integer,
+  2: String str,
+  3: Boolean boolean_field,
+  4: Double dbl,
+  5: Byte bite,
+  6: map<i32, Integer> intmap,
+  7: Map somemap,
+}
+
+exception Exception {
+  1: string msg
+}
+
+service AsyncNonblockingService {
+  Object mymethod(
+    1: Integer integer,
+    2: String str,
+    3: Boolean boolean_field,
+    4: Double dbl,
+    5: Byte bite,
+    6: map<i32, Integer> intmap,
+    7: Map somemap,
+  ) throws (1:Exception ex);
+}

--- a/tests/fixtures/JsDeepConstructorTest.thrift
+++ b/tests/fixtures/JsDeepConstructorTest.thrift
@@ -1,0 +1,18 @@
+struct Simple {
+  1: string value
+}
+
+struct Complex {
+  1: Simple struct_field
+  2: list<Simple> struct_list_field
+  3: set<Simple> struct_set_field
+  4: map<string,Simple> struct_map_field
+  5: list<set<map<string,list<Simple>>>> struct_nested_containers_field
+  6: map<string, list<map<string,Simple>> > struct_nested_containers_field2
+  7: list<list<string>> list_of_list_field
+  8: list<list<list<string>>> list_of_list_of_list_field
+}
+
+struct ComplexList {
+  1: list<Complex> struct_list_field;
+}

--- a/tests/fixtures/ManyOptionals.thrift
+++ b/tests/fixtures/ManyOptionals.thrift
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The java codegenerator has a few different codepaths depending
+// on how many optionals the struct has; this attempts to exercise
+// them.
+
+namespace java thrift.test
+
+struct Opt4 {
+  1: i32 def1;
+  2: i32 def2;
+  3: i32 def3;
+  4: i32 def4;
+}
+
+struct Opt13 {
+  1: i32 def1;
+  2: i32 def2;
+  3: i32 def3;
+  4: i32 def4;
+  5: i32 def5;
+  6: i32 def6;
+  7: i32 def7;
+  8: i32 def8;
+  9: i32 def9;
+  10: i32 def10;
+  11: i32 def11;
+  12: i32 def12;
+  13: i32 def13;
+}
+
+struct Opt30 {
+  1: i32 def1;
+  2: i32 def2;
+  3: i32 def3;
+  4: i32 def4;
+  5: i32 def5;
+  6: i32 def6;
+  7: i32 def7;
+  8: i32 def8;
+  9: i32 def9;
+  10: i32 def10;
+  11: i32 def11;
+  12: i32 def12;
+  13: i32 def13;
+  14: i32 def14;
+  15: i32 def15;
+  16: i32 def16;
+  17: i32 def17;
+  18: i32 def18;
+  19: i32 def19;
+  20: i32 def20;
+  21: i32 def21;
+  22: i32 def22;
+  23: i32 def23;
+  24: i32 def24;
+  25: i32 def25;
+  26: i32 def26;
+  27: i32 def27;
+  28: i32 def28;
+  29: i32 def29;
+  30: i32 def30;
+}
+
+struct Opt64 {
+  1: i32 def1;
+  2: i32 def2;
+  3: i32 def3;
+  4: i32 def4;
+  5: i32 def5;
+  6: i32 def6;
+  7: i32 def7;
+  8: i32 def8;
+  9: i32 def9;
+  10: i32 def10;
+  11: i32 def11;
+  12: i32 def12;
+  13: i32 def13;
+  14: i32 def14;
+  15: i32 def15;
+  16: i32 def16;
+  17: i32 def17;
+  18: i32 def18;
+  19: i32 def19;
+  20: i32 def20;
+  21: i32 def21;
+  22: i32 def22;
+  23: i32 def23;
+  24: i32 def24;
+  25: i32 def25;
+  26: i32 def26;
+  27: i32 def27;
+  28: i32 def28;
+  29: i32 def29;
+  30: i32 def30;
+  31: i32 def31;
+  32: i32 def32;
+  33: i32 def33;
+  34: i32 def34;
+  35: i32 def35;
+  36: i32 def36;
+  37: i32 def37;
+  38: i32 def38;
+  39: i32 def39;
+  40: i32 def40;
+  41: i32 def41;
+  42: i32 def42;
+  43: i32 def43;
+  44: i32 def44;
+  45: i32 def45;
+  46: i32 def46;
+  47: i32 def47;
+  48: i32 def48;
+  49: i32 def49;
+  50: i32 def50;
+  51: i32 def51;
+  52: i32 def52;
+  53: i32 def53;
+  54: i32 def54;
+  55: i32 def55;
+  56: i32 def56;
+  57: i32 def57;
+  58: i32 def58;
+  59: i32 def59;
+  60: i32 def60;
+  61: i32 def61;
+  62: i32 def62;
+  63: i32 def63;
+  64: i32 def64;
+}
+
+struct Opt80 {
+  1: i32 def1;
+  2: i32 def2;
+  3: i32 def3;
+  4: i32 def4;
+  5: i32 def5;
+  6: i32 def6;
+  7: i32 def7;
+  8: i32 def8;
+  9: i32 def9;
+  10: i32 def10;
+  11: i32 def11;
+  12: i32 def12;
+  13: i32 def13;
+  14: i32 def14;
+  15: i32 def15;
+  16: i32 def16;
+  17: i32 def17;
+  18: i32 def18;
+  19: i32 def19;
+  20: i32 def20;
+  21: i32 def21;
+  22: i32 def22;
+  23: i32 def23;
+  24: i32 def24;
+  25: i32 def25;
+  26: i32 def26;
+  27: i32 def27;
+  28: i32 def28;
+  29: i32 def29;
+  30: i32 def30;
+  31: i32 def31;
+  32: i32 def32;
+  33: i32 def33;
+  34: i32 def34;
+  35: i32 def35;
+  36: i32 def36;
+  37: i32 def37;
+  38: i32 def38;
+  39: i32 def39;
+  40: i32 def40;
+  41: i32 def41;
+  42: i32 def42;
+  43: i32 def43;
+  44: i32 def44;
+  45: i32 def45;
+  46: i32 def46;
+  47: i32 def47;
+  48: i32 def48;
+  49: i32 def49;
+  50: i32 def50;
+  51: i32 def51;
+  52: i32 def52;
+  53: i32 def53;
+  54: i32 def54;
+  55: i32 def55;
+  56: i32 def56;
+  57: i32 def57;
+  58: i32 def58;
+  59: i32 def59;
+  60: i32 def60;
+  61: i32 def61;
+  62: i32 def62;
+  63: i32 def63;
+  64: i32 def64;
+  65: i32 def65;
+  66: i32 def66;
+  67: i32 def67;
+  68: i32 def68;
+  69: i32 def69;
+  70: i32 def70;
+  71: i32 def71;
+  72: i32 def72;
+  73: i32 def73;
+  74: i32 def74;
+  75: i32 def75;
+  76: i32 def76;
+  77: i32 def77;
+  78: i32 def78;
+  79: i32 def79;
+  80: i32 def80;
+}
+

--- a/tests/fixtures/ManyTypedefs.thrift
+++ b/tests/fixtures/ManyTypedefs.thrift
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// This is to make sure you don't mess something up when you change typedef code.
+// Generate it with the old and new thrift and make sure they are the same.
+/*
+rm -rf gen-* orig-*
+mkdir old new
+thrift --gen cpp --gen java --gen php --gen phpi --gen py --gen rb --gen xsd --gen perl --gen ocaml --gen erl --gen hs --strict ManyTypedefs.thrift
+mv gen-* old
+../compiler/cpp/thrift --gen cpp --gen java --gen php --gen phpi --gen py --gen rb --gen xsd --gen perl --gen ocaml --gen erl --gen hs --strict ManyTypedefs.thrift
+mv gen-* new
+diff -ur old new
+rm -rf old new
+# There should be no output.
+*/
+
+typedef i32 int32
+typedef list<map<int32, string>> biglist
+
+struct struct1 {
+  1: int32 myint;
+  2: biglist mylist;
+}
+
+exception exception1 {
+  1: biglist alist;
+  2: struct1 mystruct;
+}
+
+service AService {
+  struct1 method1(1: int32 myint) throws (1: exception1 exn);
+  biglist method2();
+}

--- a/tests/fixtures/NameConflictTest.thrift
+++ b/tests/fixtures/NameConflictTest.thrift
@@ -1,0 +1,110 @@
+// Naming testcases, sepcifically for these tickets (but not limited to them)
+// THRIFT-2508 Uncompileable C# code due to language keywords in IDL
+// THRIFT-2557 error CS0542 member names cannot be the same as their enclosing type
+
+
+struct using {
+    1: double single
+    2: double integer
+}
+
+struct delegate {
+    1: string partial
+    2: delegate delegate
+}
+
+struct get {
+    1: bool sbyte
+}
+
+struct partial {
+    1: using using
+    2: bool read
+    3: bool write
+}
+
+enum Maybe {
+  JUST = 1,
+  TRUE = 2,
+  FALSE = 3
+}
+
+enum Either {
+  LEFT = 1,
+  RIGHT = 2
+}
+
+struct foldr {
+  1: string id
+}
+
+struct of {
+  1: string let
+  2: string where
+}
+
+struct ofOf {
+  1: of Of
+}
+
+
+struct ClassAndProp {
+  1: bool ClassAndProp
+  2: bool ClassAndProp_
+  3: bool ClassAndProp__
+  4: bool ClassAndProper
+}
+
+struct second_chance {
+  1: bool SECOND_CHANCE
+  2: bool SECOND_CHANCE_
+  3: bool SECOND_CHANCE__
+  4: bool SECOND_CHANCES
+}
+
+struct NOW_EAT_THIS {
+  1: bool now_eat_this
+  2: bool now_eat_this_
+  3: bool now_eat_this__
+  4: bool now_eat_this_and_this
+}
+
+struct TheEdgeCase {
+  1: bool theEdgeCase
+  2: bool theEdgeCase_
+  3: bool theEdgeCase__
+  4: bool TheEdgeCase
+  5: bool TheEdgeCase_
+  6: bool TheEdgeCase__
+}
+
+struct Tricky_ {
+  1: bool tricky
+  2: bool Tricky
+}
+
+struct Nested {
+  1: ClassAndProp ClassAndProp
+  2: second_chance second_chance
+  3: NOW_EAT_THIS NOW_EAT_THIS
+  4: TheEdgeCase TheEdgeCase
+  5: Tricky_ Tricky_
+  6: Nested Nested
+}
+
+exception Problem_ {
+  1: bool problem
+  2: bool Problem
+}
+
+
+service extern {
+    delegate event(1: partial get)
+    void Foo(1: Nested Foo_args) throws (1: Problem_ Foo_result)
+}
+
+service qualified {
+    Maybe maybe(1: Maybe foldr)
+    Either either(1: foldr of)
+}
+// eof

--- a/tests/fixtures/OptionalRequiredTest.thrift
+++ b/tests/fixtures/OptionalRequiredTest.thrift
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Contains some contributions under the Thrift Software License.
+ * Please see doc/old-thrift-license.txt in the Thrift distribution for
+ * details.
+ */
+
+namespace c_glib TTest
+namespace cpp thrift.test
+namespace java thrift.test
+
+struct OldSchool {
+  1: i16    im_int;
+  2: string im_str;
+  3: list<map<i32,string>> im_big;
+}
+
+struct Simple {
+  1: /* :) */ i16 im_default;
+  2: required i16 im_required;
+  3: optional i16 im_optional;
+}
+
+struct Tricky1 {
+  1: /* :) */ i16 im_default;
+}
+
+struct Tricky2 {
+  1: optional i16 im_optional;
+}
+
+struct Tricky3 {
+  1: required i16 im_required;
+}
+
+struct OptionalDefault {
+  1: optional i16 opt_int = 1234;
+  2: optional string opt_str = "default";
+}
+
+struct Complex {
+  1:          i16 cp_default;
+  2: required i16 cp_required;
+  3: optional i16 cp_optional;
+  4:          map<i16,Simple> the_map;
+  5: required Simple req_simp;
+  6: optional Simple opt_simp;
+}
+
+struct ManyOpt {
+  1: optional i32 opt1;
+  2: optional i32 opt2;
+  3: optional i32 opt3;
+  4:          i32 def4;
+  5: optional i32 opt5;
+  6: optional i32 opt6;
+}
+
+struct JavaTestHelper {
+  1: required i32    req_int;
+  2: optional i32    opt_int;
+  3: required string req_obj;
+  4: optional string opt_obj;
+  5: required binary req_bin;
+  6: optional binary opt_bin;
+}
+
+struct Binaries {
+  4: binary bin;
+  5: required binary req_bin;
+  6: optional binary opt_bin;
+}

--- a/tests/fixtures/Recursive.thrift
+++ b/tests/fixtures/Recursive.thrift
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+struct RecTree {
+  1: list<RecTree> children
+  2: i16 item
+}
+
+struct RecList {
+  1: RecList & nextitem
+  3: i16 item
+}
+
+struct CoRec {
+  1:  CoRec2 & other
+}
+
+struct CoRec2 {
+  1: CoRec other
+}
+
+struct VectorTest {
+  1: list<RecList> lister;
+}
+
+service TestService
+{
+  RecTree echoTree(1:RecTree tree)
+  RecList echoList(1:RecList lst)
+  CoRec echoCoRec(1:CoRec item)
+}

--- a/tests/fixtures/ReuseObjects.thrift
+++ b/tests/fixtures/ReuseObjects.thrift
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The java codegenerator has option to reuse objects for deserialization
+
+namespace java thrift.test
+
+include "ThriftTest.thrift"
+
+struct Reuse {
+  1: i32 val1;
+  2: set<string> val2;
+}
+

--- a/tests/fixtures/SmallTest.thrift
+++ b/tests/fixtures/SmallTest.thrift
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+namespace rb TestNamespace
+
+struct Goodbyez {
+  1: i32 val = 325;
+}
+
+senum Thinger {
+  "ASDFKJ",
+  "r32)*F#@",
+  "ASDFLJASDF"
+}
+
+struct BoolPasser {
+  1: bool value = 1
+}
+
+struct Hello {
+  1: i32 simple = 53,
+  2: map<i32,i32> complex = {23:532, 6243:632, 2355:532},
+  3: map<i32, map<i32,i32>> complexer,
+  4: string words = "words",
+  5: Goodbyez thinz = {'val' : 36632}
+}
+
+const map<i32,map<i32,i32>> CMAP = { 235: {235:235}, 53:{53:53} }
+const i32 CINT = 325;
+const Hello WHOA = {'simple' : 532}
+
+exception Goodbye {
+  1: i32 simple,
+  2: map<i32,i32> complex,
+  3: map<i32, map<i32,i32>> complexer,
+}
+
+service SmallService {
+  Thinger testThinger(1:Thinger bootz),
+  Hello testMe(1:i32 hello=64, 2: Hello wonk) throws (1: Goodbye g),
+  void testVoid() throws (1: Goodbye g),
+  i32 testI32(1:i32 boo)
+}

--- a/tests/fixtures/StressTest.thrift
+++ b/tests/fixtures/StressTest.thrift
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace cpp test.stress
+namespace d thrift.test.stress
+namespace go stress
+
+service Service {
+
+  void echoVoid(),
+  i8 echoByte(1: i8 arg),
+  i32 echoI32(1: i32 arg),
+  i64 echoI64(1: i64 arg),
+  string echoString(1: string arg),
+  list<i8>  echoList(1: list<i8> arg),
+  set<i8>  echoSet(1: set<i8> arg),
+  map<i8, i8>  echoMap(1: map<i8, i8> arg),
+}
+

--- a/tests/fixtures/ThriftTest.thrift
+++ b/tests/fixtures/ThriftTest.thrift
@@ -1,0 +1,411 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Contains some contributions under the Thrift Software License.
+ * Please see doc/old-thrift-license.txt in the Thrift distribution for
+ * details.
+ */
+
+namespace c_glib TTest
+namespace java thrift.test
+namespace cpp thrift.test
+namespace rb Thrift.Test
+namespace perl ThriftTest
+namespace csharp Thrift.Test
+namespace js ThriftTest
+namespace st ThriftTest
+namespace py ThriftTest
+namespace py.twisted ThriftTest
+namespace go thrifttest
+namespace php ThriftTest
+namespace delphi Thrift.Test
+namespace cocoa ThriftTest
+namespace lua ThriftTest
+namespace xsd test (uri = 'http://thrift.apache.org/ns/ThriftTest')
+
+// Presence of namespaces and sub-namespaces for which there is
+// no generator should compile with warnings only
+namespace noexist ThriftTest
+namespace cpp.noexist ThriftTest
+
+namespace * thrift.test
+
+/**
+ * Docstring!
+ */
+enum Numberz
+{
+  ONE = 1,
+  TWO,
+  THREE,
+  FIVE = 5,
+  SIX,
+  EIGHT = 8
+}
+
+const Numberz myNumberz = Numberz.ONE;
+// the following is expected to fail:
+// const Numberz urNumberz = ONE;
+
+typedef i64 UserId
+
+struct Bonk
+{
+  1: string message,
+  2: i32 type
+}
+
+typedef map<string,Bonk> MapType
+
+struct Bools {
+  1: bool im_true,
+  2: bool im_false,
+}
+
+struct Xtruct
+{
+  1:  string string_thing,
+  4:  i8     byte_thing,
+  9:  i32    i32_thing,
+  11: i64    i64_thing
+}
+
+struct Xtruct2
+{
+  1: i8     byte_thing,  // used to be byte, hence the name
+  2: Xtruct struct_thing,
+  3: i32    i32_thing
+}
+
+struct Xtruct3
+{
+  1:  string string_thing,
+  4:  i32    changed,
+  9:  i32    i32_thing,
+  11: i64    i64_thing
+}
+
+
+struct Insanity
+{
+  1: map<Numberz, UserId> userMap,
+  2: list<Xtruct> xtructs
+} (python.immutable= "")
+
+struct CrazyNesting {
+  1: string string_field,
+  2: optional set<Insanity> set_field,
+  // Do not insert line break as test/go/Makefile.am is removing this line with pattern match
+  3: required list<map<set<i32> (python.immutable = ""), map<i32,set<list<map<Insanity,string>(python.immutable = "")> (python.immutable = "")>>>> list_field,
+  4: binary binary_field
+}
+
+union SomeUnion {
+  1: map<Numberz, UserId> map_thing,
+  2: string string_thing,
+  3: i32 i32_thing,
+  4: Xtruct3 xtruct_thing,
+  5: Insanity insanity_thing
+}
+
+exception Xception {
+  1: i32 errorCode,
+  2: string message
+}
+
+exception Xception2 {
+  1: i32 errorCode,
+  2: Xtruct struct_thing
+}
+
+struct EmptyStruct {}
+
+struct OneField {
+  1: EmptyStruct field
+}
+
+service ThriftTest
+{
+  /**
+   * Prints "testVoid()" and returns nothing.
+   */
+  void         testVoid(),
+
+  /**
+   * Prints 'testString("%s")' with thing as '%s'
+   * @param string thing - the string to print
+   * @return string - returns the string 'thing'
+   */
+  string       testString(1: string thing),
+
+  /**
+   * Prints 'testBool("%s")' where '%s' with thing as 'true' or 'false'
+   * @param bool  thing - the bool data to print
+   * @return bool  - returns the bool 'thing'
+   */
+  bool         testBool(1: bool thing),
+
+  /**
+   * Prints 'testByte("%d")' with thing as '%d'
+   * The types i8 and byte are synonyms, use of i8 is encouraged, byte still exists for the sake of compatibility.
+   * @param byte thing - the i8/byte to print
+   * @return i8 - returns the i8/byte 'thing'
+   */
+  i8           testByte(1: i8 thing),
+
+  /**
+   * Prints 'testI32("%d")' with thing as '%d'
+   * @param i32 thing - the i32 to print
+   * @return i32 - returns the i32 'thing'
+   */
+  i32          testI32(1: i32 thing),
+
+  /**
+   * Prints 'testI64("%d")' with thing as '%d'
+   * @param i64 thing - the i64 to print
+   * @return i64 - returns the i64 'thing'
+   */
+  i64          testI64(1: i64 thing),
+
+  /**
+   * Prints 'testDouble("%f")' with thing as '%f'
+   * @param double thing - the double to print
+   * @return double - returns the double 'thing'
+   */
+  double       testDouble(1: double thing),
+
+  /**
+   * Prints 'testBinary("%s")' where '%s' is a hex-formatted string of thing's data
+   * @param binary  thing - the binary data to print
+   * @return binary  - returns the binary 'thing'
+   */
+  binary       testBinary(1: binary thing),
+
+  /**
+   * Prints 'testStruct("{%s}")' where thing has been formatted into a string of comma separated values
+   * @param Xtruct thing - the Xtruct to print
+   * @return Xtruct - returns the Xtruct 'thing'
+   */
+  Xtruct       testStruct(1: Xtruct thing),
+
+  /**
+   * Prints 'testNest("{%s}")' where thing has been formatted into a string of the nested struct
+   * @param Xtruct2 thing - the Xtruct2 to print
+   * @return Xtruct2 - returns the Xtruct2 'thing'
+   */
+  Xtruct2      testNest(1: Xtruct2 thing),
+
+  /**
+   * Prints 'testMap("{%s")' where thing has been formatted into a string of  'key => value' pairs
+   *  separated by commas and new lines
+   * @param map<i32,i32> thing - the map<i32,i32> to print
+   * @return map<i32,i32> - returns the map<i32,i32> 'thing'
+   */
+  map<i32,i32> testMap(1: map<i32,i32> thing),
+
+  /**
+   * Prints 'testStringMap("{%s}")' where thing has been formatted into a string of  'key => value' pairs
+   *  separated by commas and new lines
+   * @param map<string,string> thing - the map<string,string> to print
+   * @return map<string,string> - returns the map<string,string> 'thing'
+   */
+  map<string,string> testStringMap(1: map<string,string> thing),
+
+  /**
+   * Prints 'testSet("{%s}")' where thing has been formatted into a string of  values
+   *  separated by commas and new lines
+   * @param set<i32> thing - the set<i32> to print
+   * @return set<i32> - returns the set<i32> 'thing'
+   */
+  set<i32>     testSet(1: set<i32> thing),
+
+  /**
+   * Prints 'testList("{%s}")' where thing has been formatted into a string of  values
+   *  separated by commas and new lines
+   * @param list<i32> thing - the list<i32> to print
+   * @return list<i32> - returns the list<i32> 'thing'
+   */
+  list<i32>    testList(1: list<i32> thing),
+
+  /**
+   * Prints 'testEnum("%d")' where thing has been formatted into it's numeric value
+   * @param Numberz thing - the Numberz to print
+   * @return Numberz - returns the Numberz 'thing'
+   */
+  Numberz      testEnum(1: Numberz thing),
+
+  /**
+   * Prints 'testTypedef("%d")' with thing as '%d'
+   * @param UserId thing - the UserId to print
+   * @return UserId - returns the UserId 'thing'
+   */
+  UserId       testTypedef(1: UserId thing),
+
+  /**
+   * Prints 'testMapMap("%d")' with hello as '%d'
+   * @param i32 hello - the i32 to print
+   * @return map<i32,map<i32,i32>> - returns a dictionary with these values:
+   *   {-4 => {-4 => -4, -3 => -3, -2 => -2, -1 => -1, }, 4 => {1 => 1, 2 => 2, 3 => 3, 4 => 4, }, }
+   */
+  map<i32,map<i32,i32>> testMapMap(1: i32 hello),
+
+  /**
+   * So you think you've got this all worked, out eh?
+   *
+   * Creates a the returned map with these values and prints it out:
+   *   { 1 => { 2 => argument,
+   *            3 => argument,
+   *          },
+   *     2 => { 6 => <empty Insanity struct>, },
+   *   }
+   * @return map<UserId, map<Numberz,Insanity>> - a map with the above values
+   */
+  map<UserId, map<Numberz,Insanity>> testInsanity(1: Insanity argument),
+
+  /**
+   * Prints 'testMulti()'
+   * @param i8 arg0 -
+   * @param i32 arg1 -
+   * @param i64 arg2 -
+   * @param map<i16, string> arg3 -
+   * @param Numberz arg4 -
+   * @param UserId arg5 -
+   * @return Xtruct - returns an Xtruct with string_thing = "Hello2, byte_thing = arg0, i32_thing = arg1
+   *    and i64_thing = arg2
+   */
+  Xtruct testMulti(1: i8 arg0, 2: i32 arg1, 3: i64 arg2, 4: map<i16, string> arg3, 5: Numberz arg4, 6: UserId arg5),
+
+  /**
+   * Print 'testException(%s)' with arg as '%s'
+   * @param string arg - a string indication what type of exception to throw
+   * if arg == "Xception" throw Xception with errorCode = 1001 and message = arg
+   * elsen if arg == "TException" throw TException
+   * else do not throw anything
+   */
+  void testException(1: string arg) throws(1: Xception err1),
+
+  /**
+   * Print 'testMultiException(%s, %s)' with arg0 as '%s' and arg1 as '%s'
+   * @param string arg - a string indication what type of exception to throw
+   * if arg0 == "Xception" throw Xception with errorCode = 1001 and message = "This is an Xception"
+   * elsen if arg0 == "Xception2" throw Xception2 with errorCode = 2002 and struct_thing.string_thing = "This is an Xception2"
+   * else do not throw anything
+   * @return Xtruct - an Xtruct with string_thing = arg1
+   */
+  Xtruct testMultiException(1: string arg0, 2: string arg1) throws(1: Xception err1, 2: Xception2 err2)
+
+  /**
+   * Print 'testOneway(%d): Sleeping...' with secondsToSleep as '%d'
+   * sleep 'secondsToSleep'
+   * Print 'testOneway(%d): done sleeping!' with secondsToSleep as '%d'
+   * @param i32 secondsToSleep - the number of seconds to sleep
+   */
+  oneway void testOneway(1:i32 secondsToSleep)
+}
+
+service SecondService
+{
+  void blahBlah()
+  /**
+   * Prints 'testString("%s")' with thing as '%s'
+   * @param string thing - the string to print
+   * @return string - returns the string 'thing'
+   */
+  string       secondtestString(1: string thing),
+}
+
+struct VersioningTestV1 {
+       1: i32 begin_in_both,
+       3: string old_string,
+       12: i32 end_in_both
+}
+
+struct VersioningTestV2 {
+       1: i32 begin_in_both,
+
+       2: i32 newint,
+       3: i8 newbyte,
+       4: i16 newshort,
+       5: i64 newlong,
+       6: double newdouble
+       7: Bonk newstruct,
+       8: list<i32> newlist,
+       9: set<i32> newset,
+       10: map<i32, i32> newmap,
+       11: string newstring,
+       12: i32 end_in_both
+}
+
+struct ListTypeVersioningV1 {
+       1: list<i32> myints;
+       2: string hello;
+}
+
+struct ListTypeVersioningV2 {
+       1: list<string> strings;
+       2: string hello;
+}
+
+struct GuessProtocolStruct {
+  7: map<string,string> map_field,
+}
+
+struct LargeDeltas {
+  1: Bools b1,
+  10: Bools b10,
+  100: Bools b100,
+  500: bool check_true,
+  1000: Bools b1000,
+  1500: bool check_false,
+  2000: VersioningTestV2 vertwo2000,
+  2500: set<string> a_set2500,
+  3000: VersioningTestV2 vertwo3000,
+  4000: list<i32> big_numbers
+}
+
+struct NestedListsI32x2 {
+  1: list<list<i32>> integerlist
+}
+struct NestedListsI32x3 {
+  1: list<list<list<i32>>> integerlist
+}
+struct NestedMixedx2 {
+  1: list<set<i32>> int_set_list
+  2: map<i32,set<string>> map_int_strset
+  3: list<map<i32,set<string>>> map_int_strset_list
+}
+struct ListBonks {
+  1: list<Bonk> bonk
+}
+struct NestedListsBonk {
+  1: list<list<list<Bonk>>> bonk
+}
+
+struct BoolTest {
+  1: optional bool b = true;
+  2: optional string s = "true";
+}
+
+struct StructA {
+  1: required string s;
+}
+
+struct StructB {
+  1: optional StructA aa;
+  2: required StructA ab;
+}

--- a/tests/fixtures/TypedefTest.thrift
+++ b/tests/fixtures/TypedefTest.thrift
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ * Contains some contributions under the Thrift Software License.
+ * Please see doc/old-thrift-license.txt in the Thrift distribution for
+ * details.
+ */
+
+namespace cpp thrift.test
+
+typedef i32 MyInt32
+typedef string MyString;
+
+struct TypedefTestStruct {
+  1: MyInt32 field_MyInt32;
+  2: MyString field_MyString;
+  3: i32 field_Int32;
+  4: string field_String;
+}
+
+typedef TypedefTestStruct MyStruct,


### PR DESCRIPTION
@nnance these are the `.thrift` files from the test suite of the C Thrift library.  I copied them over and added some comments about things we don't support.  I'm not sure if you want to include them verbatim.