### PR TITLE
Add support for namespace * (closes creditkarma/thrift-parser#15)

### DIFF
--- a/tests/test-parse.expection.json
+++ b/tests/test-parse.expection.json
@@ -2,6 +2,9 @@
   "namespace": {
     "php": {
       "serviceName": "hehe"
+    },
+    "*": {
+      "serviceName": "haha"
     }
   },
   "typedef": {

--- a/tests/test.thrift
+++ b/tests/test.thrift
@@ -1,4 +1,5 @@
 namespace php hehe
+namespace * haha
 
 /******
  * Types

--- a/thrift-parser.js
+++ b/thrift-parser.js
@@ -148,6 +148,23 @@ module.exports = (buffer, offset = 0) => {
     return value;
   };
 
+  const readScope = () => {
+    let i = 0;
+    let result = [];
+    let byte = buffer[offset];
+    while (
+      (byte >= 97 && byte <= 122) || // a-z
+      byte === 95 ||                 // _
+      (byte >= 65 && byte <= 90) ||  // A-Z
+      (byte >= 48 && byte <= 57) ||  // 0-9
+      (byte === 42)                  // *
+    ) byte = buffer[offset + ++i];
+    if (i === 0) throw 'Unexpected token';
+    let value = buffer.toString('utf8', offset, offset += i);
+    readSpace();
+    return value;
+  };
+
   const readNumberValue = () => {
     let result = [];
     for (;;) {
@@ -321,7 +338,7 @@ module.exports = (buffer, offset = 0) => {
 
   const readNamespace = () => {
     let subject = readKeyword('namespace');
-    let name = readName();
+    let name = readScope();
     let serviceName = readRefValue()['='].join('.');
     return { subject, name, serviceName };
   };


### PR DESCRIPTION
This just a copy-paste of the `readName` function renamed to `readScope` and adjusted to include `*` as a valid character.  The spec doesn't identify individual characters that make up a scope, but instead a list of strings to match.  We will need to make a decision on that and this method can be adjusted at that time.

Also, added a `*` namespace to the test.