### PR TITLE
Add support for optional FieldID in structs (closes creditkarma/thrift-parser#6)

### DIFF
--- a/tests/test-parse.expection.json
+++ b/tests/test-parse.expection.json
@@ -134,6 +134,23 @@
         "type": "i16",
         "name": "field3"
       }
+    ],
+    "NoID": [
+      {
+        "id": -1,
+        "type": "i32",
+        "name": "num0"
+      },
+      {
+        "id": -2,
+        "type": "i32",
+        "name": "num1"
+      },
+      {
+        "id": -3,
+        "type": "i32",
+        "name": "num2"
+      }
     ]
   },
   "exception": {

--- a/tests/test.thrift
+++ b/tests/test.thrift
@@ -41,6 +41,12 @@ struct Struct2 {
     4: required i16 field3,
 }
 
+struct NoID {
+  i32 num0,
+  i32 num1;
+  i32 num2;
+}
+
 exception Exception1 {
     1: required i32 error_code,
     2: required string error_name,

--- a/thrift-parser.js
+++ b/thrift-parser.js
@@ -286,14 +286,25 @@ module.exports = (buffer, offset = 0) => {
 
   const readStructBlock = () => {
     readCharCode(123); // {
-    let receiver = readUntilThrow(readStructItem);
+    let receiver  = readUntilThrow(readStructItem);
+    let defaultId = -1;
+    receiver.forEach((block) => {
+      if (!block.id) {
+        block.id = defaultId;
+        defaultId -= 1;
+      }
+    })
     readCharCode(125); // }
     return receiver;
   };
 
   const readStructItem = () => {
-    let id = readNumberValue();
-    readCharCode(58); // :
+    // Read the FieldID, it might not exist
+    let id = readAnyOne(readNumberValue, readNoop);
+    // If the FieldID exists, it needs to be followed by :
+    if (id) {
+      readCharCode(58); // :
+    }
     let option = readAnyOne(() => readKeyword('required'), () => readKeyword('optional'), readNoop);
     let type = readType();
     let name = readName();


### PR DESCRIPTION
This likely needs to be refactored so the logic applies to function arguments also.  I'll likely tackle that with #10.