### PR TITLE
Add support for union keyword (closes creditkarma/thrift-parser#7)

### DIFF
--- a/tests/test-parse.expection.json
+++ b/tests/test-parse.expection.json
@@ -166,6 +166,27 @@
       }
     ]
   },
+  "union": {
+    "Union1": {
+      "items": [
+        {
+          "id": 1,
+          "type": "string",
+          "name": "field1"
+        },
+        {
+          "id": 2,
+          "type": "int",
+          "name": "field2"
+        },
+        {
+          "id": 3,
+          "type": "string",
+          "name": "dropOption"
+        }
+      ]
+    }
+  },
   "exception": {
     "Exception1": [
       {

--- a/tests/test.thrift
+++ b/tests/test.thrift
@@ -47,6 +47,12 @@ struct Struct2 {
     4: required i16 field3,
 }
 
+union Union1 {
+  1: string field1;
+  2: int field2;
+  3: required string dropOption;
+}
+
 exception Exception1 {
     1: required i32 error_code,
     2: required string error_name,

--- a/thrift-parser.js
+++ b/thrift-parser.js
@@ -359,6 +359,34 @@ module.exports = (buffer, offset = 0) => {
     return result;
   };
 
+  const readUnion = () => {
+    let subject = readKeyword('union');
+    let name = readName();
+    let items = readUnionBlock();
+    return { subject, name, items };
+  };
+
+  const readUnionBlock = () => {
+    readCharCode(123); // {
+    let receiver = readUntilThrow(readUnionItem);
+    readCharCode(125); // }
+    return receiver;
+  };
+
+  const readUnionItem = () => {
+    let id = readNumberValue();
+    readCharCode(58); // :
+    // Read the keyword but drop it
+    readAnyOne(() => readKeyword('required'), () => readKeyword('optional'), readNoop);
+    let type = readType();
+    let name = readName();
+    let defaultValue = readAssign();
+    readComma();
+    let result = { id, type, name };
+    if (defaultValue !== void 0) result.defaultValue = defaultValue;
+    return result;
+  };
+
   const readException = () => {
     let subject = readKeyword('exception');
     let name = readName();
@@ -419,7 +447,7 @@ module.exports = (buffer, offset = 0) => {
   };
 
   const readSubject = () => {
-    return readAnyOne(readTypedef, readConst, readEnum, readStruct, readException, readService, readNamespace);
+    return readAnyOne(readTypedef, readConst, readEnum, readStruct, readUnion, readException, readService, readNamespace);
   };
 
   const readThrift = () => {


### PR DESCRIPTION
Very similar logic to the `struct` keyword but drops the `option` keyword. 