### PR TITLE
Add support for extends keyword (closes creditkarma/thrift-parser#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,96 +39,91 @@ Results
 ```json
 {
   "struct": {
-    "MyStruct": {
-      "items": [
-        {
-          "id": "1",
-          "option": "required",
-          "type": "int",
-          "name": "id"
-        },
-        {
-          "id": "2",
-          "option": "required",
-          "type": "bool",
-          "name": "field1"
-        },
-        {
-          "id": "4",
-          "option": "required",
-          "type": "i16",
-          "name": "field"
-        }
-      ]
-    }
+    "MyStruct": [
+      {
+        "id": 1,
+        "option": "required",
+        "type": "int",
+        "name": "id"
+      },
+      {
+        "id": 2,
+        "option": "required",
+        "type": "bool",
+        "name": "field1"
+      },
+      {
+        "id": 4,
+        "option": "required",
+        "type": "i16",
+        "name": "field"
+      }
+    ]
   },
   "exception": {
-    "Exception1": {
-      "items": [
-        {
-          "id": "1",
-          "option": "required",
-          "type": "i32",
-          "name": "error_code"
-        },
-        {
-          "id": "2",
-          "option": "required",
-          "type": "string",
-          "name": "error_name"
-        },
-        {
-          "id": "3",
-          "option": "optional",
-          "type": "string",
-          "name": "message"
-        }
-      ]
-    },
-    "Exception2": {
-      "items": [
-        {
-          "id": "1",
-          "option": "required",
-          "type": "i32",
-          "name": "error_code"
-        },
-        {
-          "id": "2",
-          "option": "required",
-          "type": "string",
-          "name": "error_name"
-        },
-        {
-          "id": "3",
-          "option": "optional",
-          "type": "string",
-          "name": "message"
-        }
-      ]
-    }
+    "Exception1": [
+      {
+        "id": 1,
+        "option": "required",
+        "type": "i32",
+        "name": "error_code"
+      },
+      {
+        "id": 2,
+        "option": "required",
+        "type": "string",
+        "name": "error_name"
+      },
+      {
+        "id": 3,
+        "option": "optional",
+        "type": "string",
+        "name": "message"
+      }
+    ],
+    "Exception2": [
+      {
+        "id": 1,
+        "option": "required",
+        "type": "i32",
+        "name": "error_code"
+      },
+      {
+        "id": 2,
+        "option": "required",
+        "type": "string",
+        "name": "error_name"
+      },
+      {
+        "id": 3,
+        "option": "optional",
+        "type": "string",
+        "name": "message"
+      }
+    ]
   },
   "service": {
     "Service1": {
-      "items": [
-        {
+      "functions": {
+        "ping": {
           "type": "bool",
           "name": "ping",
           "args": [],
           "throws": [
             {
-              "id": "1",
+              "id": 1,
               "type": "Exception1",
               "name": "user_exception"
             },
             {
-              "id": "2",
+              "id": 2,
               "type": "Exception2",
               "name": "system_exception"
             }
-          ]
+          ],
+          "oneway": false
         },
-        {
+        "test": {
           "type": {
             "name": "list",
             "valueType": "MyStruct"
@@ -136,25 +131,26 @@ Results
           "name": "test",
           "args": [
             {
-              "id": "1",
+              "id": 1,
               "type": "MyStruct",
               "name": "ms"
             }
           ],
           "throws": [
             {
-              "id": "1",
+              "id": 1,
               "type": "Exception1",
               "name": "user_exception"
             },
             {
-              "id": "2",
+              "id": 2,
               "type": "Exception2",
               "name": "system_exception"
             }
-          ]
+          ],
+          "oneway": false
         }
-      ]
+      }
     }
   }
 }

--- a/tests/test-demo.expection.json
+++ b/tests/test-demo.expection.json
@@ -65,51 +65,52 @@
   },
   "service": {
     "Service1": {
-      "ping": {
-        "type": "bool",
-        "name": "ping",
-        "args": [],
-        "throws": [
-          {
-            "id": 1,
-            "type": "Exception1",
-            "name": "user_exception"
-          },
-          {
-            "id": 2,
-            "type": "Exception2",
-            "name": "system_exception"
-          }
-        ],
-        "oneway": false
-      },
-      "test": {
-        "type": {
-          "name": "list",
-          "valueType": "MyStruct"
+      "functions": {
+        "ping": {
+          "type": "bool",
+          "name": "ping",
+          "args": [],
+          "throws": [
+            {
+              "id": 1,
+              "type": "Exception1",
+              "name": "user_exception"
+            },
+            {
+              "id": 2,
+              "type": "Exception2",
+              "name": "system_exception"
+            }
+          ],
+          "oneway": false
         },
-        "name": "test",
-        "args": [
-          {
-            "id": 1,
-            "type": "MyStruct",
-            "name": "ms"
-          }
-        ],
-        "throws": [
-          {
-            "id": 1,
-            "type": "Exception1",
-            "name": "user_exception"
+        "test": {
+          "type": {
+            "name": "list",
+            "valueType": "MyStruct"
           },
-          {
-            "id": 2,
-            "type": "Exception2",
-            "name": "system_exception"
-          }
-        ],
-        "oneway": false
-
+          "name": "test",
+          "args": [
+            {
+              "id": 1,
+              "type": "MyStruct",
+              "name": "ms"
+            }
+          ],
+          "throws": [
+            {
+              "id": 1,
+              "type": "Exception1",
+              "name": "user_exception"
+            },
+            {
+              "id": 2,
+              "type": "Exception2",
+              "name": "system_exception"
+            }
+          ],
+          "oneway": false
+        }
       }
     }
   }

--- a/tests/test-parse.expection.json
+++ b/tests/test-parse.expection.json
@@ -210,134 +210,162 @@
   },
   "service": {
     "Service1": {
-      "ping": {
-        "type": "bool",
-        "name": "ping",
-        "args": [],
-        "throws": [
-          {
-            "id": 1,
-            "type": "Exception1",
-            "name": "user_exception"
-          },
-          {
-            "id": 2,
-            "type": "Exception2",
-            "name": "system_exception"
-          }
-        ],
-        "oneway": false
-      },
-      "test": {
-        "type": {
-          "name": "list",
-          "valueType": {
-            "name": "map",
-            "keyType": "Struct1",
-            "valueType": "Struct2"
-          }
+      "functions": {
+        "ping": {
+          "type": "bool",
+          "name": "ping",
+          "args": [],
+          "throws": [
+            {
+              "id": 1,
+              "type": "Exception1",
+              "name": "user_exception"
+            },
+            {
+              "id": 2,
+              "type": "Exception2",
+              "name": "system_exception"
+            }
+          ],
+          "oneway": false
         },
-        "name": "test",
-        "args": [
-          {
-            "id": 1,
-            "type": "Struct1",
-            "name": "s1"
+        "test": {
+          "type": {
+            "name": "list",
+            "valueType": {
+              "name": "map",
+              "keyType": "Struct1",
+              "valueType": "Struct2"
+            }
           },
-          {
-            "id": 2,
-            "type": "Struct2",
-            "name": "s2"
-          }
-        ],
-        "throws": [
-          {
-            "id": 1,
-            "type": "Exception1",
-            "name": "user_exception"
-          },
-          {
-            "id": 2,
-            "type": "Exception2",
-            "name": "system_exception"
-          }
-        ],
-        "oneway": false
-      },
-      "test2": {
-        "type": {
-          "name": "list",
-          "valueType": {
-            "name": "set",
-            "valueType": "Struct1"
-          }
+          "name": "test",
+          "args": [
+            {
+              "id": 1,
+              "type": "Struct1",
+              "name": "s1"
+            },
+            {
+              "id": 2,
+              "type": "Struct2",
+              "name": "s2"
+            }
+          ],
+          "throws": [
+            {
+              "id": 1,
+              "type": "Exception1",
+              "name": "user_exception"
+            },
+            {
+              "id": 2,
+              "type": "Exception2",
+              "name": "system_exception"
+            }
+          ],
+          "oneway": false
         },
-        "name": "test2",
-        "args": [
-          {
-            "id": 1,
-            "type": "Struct1",
-            "name": "s1"
-          }
-        ],
-        "throws": [
-          {
-            "id": 1,
-            "type": "Exception1",
-            "name": "user_exception"
+        "test2": {
+          "type": {
+            "name": "list",
+            "valueType": {
+              "name": "set",
+              "valueType": "Struct1"
+            }
           },
-          {
-            "id": 2,
-            "type": "Exception2",
-            "name": "system_exception"
-          }
-        ],
-        "oneway": false
+          "name": "test2",
+          "args": [
+            {
+              "id": 1,
+              "type": "Struct1",
+              "name": "s1"
+            }
+          ],
+          "throws": [
+            {
+              "id": 1,
+              "type": "Exception1",
+              "name": "user_exception"
+            },
+            {
+              "id": 2,
+              "type": "Exception2",
+              "name": "system_exception"
+            }
+          ],
+          "oneway": false
+        }
       }
     },
     "Service2": {
-      "ping": {
-        "type": "bool",
-        "name": "ping",
-        "args": [],
-        "throws": [],
-        "oneway": false
-      },
-      "foo": {
-        "type": "void",
-        "name": "foo",
-        "args": [],
-        "throws": [],
-        "oneway": true
-      },
-      "test": {
-        "type": "Json",
-        "name": "test",
-        "args": [
-          {
-            "id": 1,
-            "type": "Struct1",
-            "name": "s1"
-          },
-          {
-            "id": 2,
-            "type": "Struct2",
-            "name": "s2"
-          }
-        ],
-        "throws": [
-          {
-            "id": 1,
-            "type": "Exception1",
-            "name": "user_exception"
-          },
-          {
-            "id": 2,
-            "type": "Exception2",
-            "name": "system_exception"
-          }
-        ],
-        "oneway": false
+      "functions": {
+        "ping": {
+          "type": "bool",
+          "name": "ping",
+          "args": [],
+          "throws": [],
+          "oneway": false
+        },
+        "foo": {
+          "type": "void",
+          "name": "foo",
+          "args": [],
+          "throws": [],
+          "oneway": true
+        },
+        "test": {
+          "type": "Json",
+          "name": "test",
+          "args": [
+            {
+              "id": 1,
+              "type": "Struct1",
+              "name": "s1"
+            },
+            {
+              "id": 2,
+              "type": "Struct2",
+              "name": "s2"
+            }
+          ],
+          "throws": [
+            {
+              "id": 1,
+              "type": "Exception1",
+              "name": "user_exception"
+            },
+            {
+              "id": 2,
+              "type": "Exception2",
+              "name": "system_exception"
+            }
+          ],
+          "oneway": false
+        }
+      }
+    },
+    "ExtendedService": {
+      "extends": "Service1",
+      "functions": {
+        "pong": {
+          "type": "bool",
+          "name": "pong",
+          "args": [],
+          "throws": [],
+          "oneway": false
+        }
+      }
+    },
+    "ExternalExtends": {
+      "extends": "external.Service1",
+      "functions": {
+        "pong": {
+          "type": "bool",
+          "name": "pong",
+          "args": [],
+          "throws": [],
+          "oneway": false
+        }
       }
     }
   }

--- a/tests/test.thrift
+++ b/tests/test.thrift
@@ -94,3 +94,11 @@ service Service2 {
     Json test(1: Struct1 s1, 2: Struct2 s2)
       throws (1: Exception1 user_exception, 2: Exception2 system_exception)
 }
+
+service ExtendedService extends Service1 {
+    bool pong()
+}
+
+service ExternalExtends extends external.Service1 {
+    bool pong()
+}

--- a/thrift-parser.js
+++ b/thrift-parser.js
@@ -366,11 +366,27 @@ module.exports = (buffer, offset = 0) => {
     return { subject, name, items };
   };
 
+  const readExtends = () => {
+    let beginning = offset;
+    try {
+      readKeyword('extends');
+      let name = readRefValue()['='].join('.');
+      return name;
+    } catch (ignore) {
+      offset = beginning;
+      return;
+    }
+  };
+
   const readService = () => {
     let subject = readKeyword('service');
     let name = readName();
-    let items = readServiceBlock();
-    return { subject, name, items }; 
+    let extend = readExtends(); // extends is a reserved keyword
+    let functions = readServiceBlock();
+    let result = { subject, name };
+    if (extend !== void 0) result.extends = extend;
+    if (functions !== void 0) result.functions = functions;
+    return result;
   };
 
   const readNamespace = () => {
@@ -434,7 +450,6 @@ module.exports = (buffer, offset = 0) => {
         delete block.name;
         switch (subject) {
           case 'exception':
-          case 'service':
           case 'struct':
             storage[subject][name] = block.items;
             break;


### PR DESCRIPTION
This is a breaking change to the AST structure of Services.  It assigns all functions defined to an object under the `functions` key and extends are assigned as a string to the `extends` key.  These keys are only present if values exist.

The compiler should be able to use the `extends` property to resolve internal/external extends.

I also updated the README example, which seemed to be out-of-date in other ways.