### PR TITLE
Add support for include keyword (closes creditkarma/thrift-parser#9)

### DIFF
--- a/tests/test-parse.expection.json
+++ b/tests/test-parse.expection.json
@@ -1,4 +1,8 @@
 {
+  "include": {
+    "okay": "okay.thrift",
+    "double.dot": "double.dot.thrift"
+  },
   "namespace": {
     "php": {
       "serviceName": "hehe"

--- a/tests/test.thrift
+++ b/tests/test.thrift
@@ -1,3 +1,6 @@
+include 'okay.thrift'
+include 'double.dot.thrift'
+
 namespace php hehe
 namespace * haha
 

--- a/thrift-parser.js
+++ b/thrift-parser.js
@@ -380,6 +380,13 @@ module.exports = (buffer, offset = 0) => {
     return { subject, name, serviceName };
   };
 
+  const readInclude = () => {
+    let subject = readKeyword('include');
+    let items = readStringValue();
+    let name = items.split('.').slice(0, -1).join('.');
+    return { subject, name, items };
+  };
+
   const readServiceBlock = () => {
     readCharCode(123); // {
     let receiver = readUntilThrow(readServiceItem, 'name');
@@ -419,7 +426,7 @@ module.exports = (buffer, offset = 0) => {
   };
 
   const readSubject = () => {
-    return readAnyOne(readTypedef, readConst, readEnum, readStruct, readException, readService, readNamespace);
+    return readAnyOne(readTypedef, readConst, readEnum, readStruct, readException, readService, readNamespace, readInclude);
   };
 
   const readThrift = () => {
@@ -436,6 +443,7 @@ module.exports = (buffer, offset = 0) => {
           case 'exception':
           case 'service':
           case 'struct':
+          case 'include':
             storage[subject][name] = block.items;
             break;
           default:


### PR DESCRIPTION
I updated the way I'm doing this.  The full filepaths should be resolved by the compiler.