### PR TITLE
Add support for ListSeparator after typedef keyword (closes creditkarma/thrift-parser#16)

### DIFF
--- a/tests/test-parse.expection.json
+++ b/tests/test-parse.expection.json
@@ -13,6 +13,12 @@
     },
     "Mobile": {
       "type": "i64"
+    },
+    "ListSep1": {
+      "type": "string"
+    },
+    "ListSep2": {
+      "type": "string"
     }
   },
   "const": {

--- a/tests/test.thrift
+++ b/tests/test.thrift
@@ -6,6 +6,8 @@ namespace * haha
  *****/
 typedef string Json
 typedef i64 Mobile
+typedef string ListSep1;
+typedef string ListSep2,
 
 /**
  * Const

--- a/thrift-parser.js
+++ b/thrift-parser.js
@@ -107,6 +107,7 @@ module.exports = (buffer, offset = 0) => {
     let subject = readKeyword('typedef');
     let type = readType();
     let name = readName();
+    readComma();
     return { subject, type, name };
   };
 


### PR DESCRIPTION
See #16 for further details about the spec/support for this.