### PR TITLE
Add basic logging feature for Union types (ref creditkarma/thrift-parser#32)

### DIFF
--- a/thrift-parser.js
+++ b/thrift-parser.js
@@ -425,7 +425,6 @@ module.exports = (buffer, offset = 0) => {
   const readUnionItem = () => {
     let id = readNumberValue();
     readCharCode(58); // :
-    // Read the keyword but drop it
     let option = readAnyOne(() => readKeyword('required'), () => readKeyword('optional'), readNoop);
     let type = readType();
     let name = readName();


### PR DESCRIPTION
This is a proof-of-concept for the logging.  I used node's built-in `debuglog` feature instead of relying on some sort of config object.

If we are happy with this pattern, I can progressively add logging as we progress with the project.