### PR TITLE
Add test harness (ref creditkarma/thrift-parser#26)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "author": "rongyi.liu@ele.me",
   "license": "MIT",
   "scripts": {
-    "test": "cd tests && ./test.sh"
+    "test": "mocha tests/index.js && cd tests && ./test.sh"
+  },
+  "devDependencies": {
+    "expect": "^1.20.2",
+    "mocha": "^3.2.0"
   }
 }

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,0 +1,34 @@
+'use strict';
+
+let expect = require('expect');
+
+let thriftParser = require('../');
+
+describe('thriftParser', function() {
+
+  it('parses simple struct', function(done) {
+    let content = `
+      struct MyStruct {
+        1: required int id,
+      }
+    `;
+
+    let expected = {
+      struct: {
+        MyStruct: [
+          {
+            id: 1,
+            option: 'required',
+            type: 'int',
+            name: 'id'
+          }
+        ]
+      }
+    };
+
+    let ast = thriftParser(content);
+
+    expect(ast).toEqual(expected);
+    done();
+  });
+});

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,4 +1,4 @@
-for js in $(find $(dirname $0) -name '*.js')
+for js in $(find $(dirname $0) -name 'test-*.js')
 do
   if node $js
   then echo "[32;1m[Done][0m [0;1m$js[0m"


### PR DESCRIPTION
This adds a very basic test harness.  If these patterns are acceptable, each item in the `test.thrift` file can be broken up into its own test.