### PR TITLE
Fix Union structure to match Struct and Exception

### DIFF
--- a/tests/test-parse.expection.json
+++ b/tests/test-parse.expection.json
@@ -201,26 +201,24 @@
     ]
   },
   "union": {
-    "Union1": {
-      "items": [
-        {
-          "id": 1,
-          "type": "string",
-          "name": "field1"
-        },
-        {
-          "id": 2,
-          "type": "int",
-          "name": "field2"
-        },
-        {
-          "id": 3,
-          "type": "string",
-          "name": "withOption",
-          "option": "required"
-        }
-      ]
-    }
+    "Union1": [
+      {
+        "id": 1,
+        "type": "string",
+        "name": "field1"
+      },
+      {
+        "id": 2,
+        "type": "int",
+        "name": "field2"
+      },
+      {
+        "id": 3,
+        "type": "string",
+        "name": "withOption",
+        "option": "required"
+      }
+    ]
   },
   "exception": {
     "Exception1": [

--- a/thrift-parser.js
+++ b/thrift-parser.js
@@ -537,6 +537,7 @@ module.exports = (buffer, offset = 0) => {
         switch (subject) {
           case 'exception':
           case 'struct':
+          case 'union':
             storage[subject][name] = block.items;
             break;
           default:


### PR DESCRIPTION
While writing the new tests, I noticed that the structure of Union isn't the same as Struct & Exception, which doesn't make sense because it is using the same parsing logic.

I'd like to get this upstreamed before a release is cut.