### PR TITLE
Except branches starting with upstream from builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ sudo: false
 language: node_js
 node_js:
   - "6"
+branches:
+  except:
+  - /^upstream/


### PR DESCRIPTION
I'm not sure if this will solve the failures on `upstream*` branches because they don't include the `.travis.yml` file but it can't hurt to include the branch exception.