### PR TITLE
Add typings for Unions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,6 +40,10 @@ type Structs = {
   [name: string]: Field[],
 }
 
+type Unions = {
+  [name: string]: Field[],
+}
+
 type Exceptions = {
   [name: string]: Field[],
 }
@@ -111,6 +115,7 @@ type JsonAST = {
   const?: Consts,
   enum?: Enums,
   struct?: Structs,
+  union?: Unions,
   exception?: Exceptions,
   service?: Services,
 };


### PR DESCRIPTION
Noticed that the typings didn't have Unions defined.