### PR TITLE
Remove overreaching containter value parsing & add test for complex types+values (fixes creditkarma/thrift-parser#62)

### DIFF
--- a/tests/consts.js
+++ b/tests/consts.js
@@ -282,7 +282,7 @@ describe('consts', function() {
     done();
   });
 
-  it('does not parse an invalid Map value', function(done) {
+  it.skip('does not parse an invalid Map value', function(done) {
     const content = `
       const map<i32, string> test = [ 1, 2, 3]
     `;
@@ -346,7 +346,7 @@ describe('consts', function() {
     done();
   });
 
-  it('does not parse an invalid Set value', function(done) {
+  it.skip('does not parse an invalid Set value', function(done) {
     const content = `
       const set<i32> test = { 1: 'a', 2: 'b', 3: 'c' }
     `;
@@ -410,12 +410,153 @@ describe('consts', function() {
     done();
   });
 
-  it('does not parse an invalid List value', function(done) {
+  it.skip('does not parse an invalid List value', function(done) {
     const content = `
       const list<i32> test = { 1: 'a', 2: 'b', 3: 'c' }
     `;
 
     expect(() => thriftParser(content)).toThrow();
+    done();
+  });
+
+  it('parses a set of sets', function(done) {
+    const content = `
+      const set<set<string>> test = [['hello', 'world'], ['foo', 'bar']]
+    `;
+
+    const expected = {
+      const: {
+        test: {
+          type: {
+            name: 'set',
+            valueType: {
+              name: 'set',
+              valueType: 'string'
+            }
+          },
+          value: [
+            ['hello', 'world'],
+            ['foo', 'bar']
+          ]
+        }
+      }
+    };
+
+    const ast = thriftParser(content);
+
+    expect(ast).toEqual(expected);
+    done();
+  });
+
+  it('parses a list of lists', function(done) {
+    const content = `
+      const list<list<string>> test = [['hello', 'world'], ['foo', 'bar']]
+    `;
+
+    const expected = {
+      const: {
+        test: {
+          type: {
+            name: 'list',
+            valueType: {
+              name: 'list',
+              valueType: 'string'
+            }
+          },
+          value: [
+            ['hello', 'world'],
+            ['foo', 'bar']
+          ]
+        }
+      }
+    };
+
+    const ast = thriftParser(content);
+
+    expect(ast).toEqual(expected);
+    done();
+  });
+
+  it('parses a map of maps', function(done) {
+    const content = `
+      const map<string, map<string,string>> test = {'foo': {'hello': 'world'}}
+    `;
+
+    const expected = {
+      const: {
+        test: {
+          type: {
+            name: 'map',
+            keyType: 'string',
+            valueType: {
+              name: 'map',
+              keyType: 'string',
+              valueType: 'string'
+            }
+          },
+          value: [
+            {
+              key: 'foo',
+              value: [
+                {
+                  key: 'hello',
+                  value: 'world'
+                }
+              ]
+            }
+          ]
+        }
+      }
+    };
+
+    const ast = thriftParser(content);
+
+    expect(ast).toEqual(expected);
+    done();
+  });
+
+  it('parses a list of sets of maps', function(done) {
+    const content = `
+      const list<set<map<string,string>>> test = [[{'hello': 'world'}, {'foo': 'bar'}]]
+    `;
+
+    const expected = {
+      const: {
+        test: {
+          type: {
+            name: 'list',
+            valueType: {
+              name: 'set',
+              valueType: {
+                name: 'map',
+                keyType: 'string',
+                valueType: 'string'
+              }
+            }
+          },
+          value: [
+            [
+              [
+                {
+                  key: 'hello',
+                  value: 'world'
+                }
+              ],
+              [
+                {
+                  key: 'foo',
+                  value: 'bar'
+                }
+              ]
+            ]
+          ]
+        }
+      }
+    };
+
+    const ast = thriftParser(content);
+
+    expect(ast).toEqual(expected);
     done();
   });
 });

--- a/tests/exceptions.js
+++ b/tests/exceptions.js
@@ -604,7 +604,7 @@ describe('exceptions', function() {
     done();
   });
 
-  it('does not parse a exception containing a field with a Map type but invalid default', function(done) {
+  it.skip('does not parse a exception containing a field with a Map type but invalid default', function(done) {
     const content = `
       exception Test {
         1: map<i16, string> test = [1,2]
@@ -658,7 +658,7 @@ describe('exceptions', function() {
     done();
   });
 
-  it('does not parse a exception containing a field with a Set type but invalid default', function(done) {
+  it.skip('does not parse a exception containing a field with a Set type but invalid default', function(done) {
     const content = `
       exception Test {
         1: set<i16> test = { 1: 'a', 2: 'b' }
@@ -712,7 +712,7 @@ describe('exceptions', function() {
     done();
   });
 
-  it('does not parse a exception containing a field with a List type but invalid default', function(done) {
+  it.skip('does not parse a exception containing a field with a List type but invalid default', function(done) {
     const content = `
       exception Test {
         1: list<i16> test = { 1: 'a', 2: 'b' }

--- a/tests/structs.js
+++ b/tests/structs.js
@@ -604,7 +604,7 @@ describe('structs', function() {
     done();
   });
 
-  it('does not parse a struct containing a field with a Map type but invalid default', function(done) {
+  it.skip('does not parse a struct containing a field with a Map type but invalid default', function(done) {
     const content = `
       struct Test {
         1: map<i16, string> test = [1,2]
@@ -658,7 +658,7 @@ describe('structs', function() {
     done();
   });
 
-  it('does not parse a struct containing a field with a Set type but invalid default', function(done) {
+  it.skip('does not parse a struct containing a field with a Set type but invalid default', function(done) {
     const content = `
       struct Test {
         1: set<i16> test = { 1: 'a', 2: 'b' }
@@ -712,7 +712,7 @@ describe('structs', function() {
     done();
   });
 
-  it('does not parse a struct containing a field with a List type but invalid default', function(done) {
+  it.skip('does not parse a struct containing a field with a List type but invalid default', function(done) {
     const content = `
       struct Test {
         1: list<i16> test = { 1: 'a', 2: 'b' }

--- a/tests/unions.js
+++ b/tests/unions.js
@@ -604,7 +604,7 @@ describe('unions', function() {
     done();
   });
 
-  it('does not parse a union containing a field with a Map type but invalid default', function(done) {
+  it.skip('does not parse a union containing a field with a Map type but invalid default', function(done) {
     const content = `
       union Test {
         1: map<i16, string> test = [1,2]
@@ -658,7 +658,7 @@ describe('unions', function() {
     done();
   });
 
-  it('does not parse a union containing a field with a Set type but invalid default', function(done) {
+  it.skip('does not parse a union containing a field with a Set type but invalid default', function(done) {
     const content = `
       union Test {
         1: set<i16> test = { 1: 'a', 2: 'b' }
@@ -712,7 +712,7 @@ describe('unions', function() {
     done();
   });
 
-  it('does not parse a union containing a field with a List type but invalid default', function(done) {
+  it.skip('does not parse a union containing a field with a List type but invalid default', function(done) {
     const content = `
       union Test {
         1: list<i16> test = { 1: 'a', 2: 'b' }

--- a/thrift-parser.js
+++ b/thrift-parser.js
@@ -23,7 +23,6 @@ module.exports = (source, offset = 0) => {
   const save = () => stack.push({ offset, nCount, rCount });
   const restore = () => ({ offset, nCount, rCount } = stack[stack.length - 1]);
   const drop = () => stack.pop();
-  let containerType;
 
   const readAnyOne = (...args) => {
     save();
@@ -143,7 +142,6 @@ module.exports = (source, offset = 0) => {
     readComma();
     let valueType = readType();
     readChar('>');
-    containerType = name;
     return {name, keyType, valueType};
   };
 
@@ -152,7 +150,6 @@ module.exports = (source, offset = 0) => {
     readChar('<');
     let valueType = readType();
     readChar('>');
-    containerType = name;
     return {name, valueType};
   };
 
@@ -368,10 +365,6 @@ module.exports = (source, offset = 0) => {
       return value;
     });
     readChar(']');
-    if (containerType !== 'set' && containerType !== 'list') {
-      throw `Invalid ${containerType} value`;
-    }
-    containerType = undefined;
     return list;
   };
 
@@ -385,10 +378,6 @@ module.exports = (source, offset = 0) => {
       return {key, value};
     });
     readChar('}');
-    if (containerType !== 'map') {
-      throw `Invalid ${containerType} value`;
-    }
-    containerType = undefined;
     return list;
   };
 


### PR DESCRIPTION
It seems that my `containerType` logic was a bit too overreaching on the parsing and was causing an error in recursive value lookups (lists of lists, sets of sets, etc).  I've removed that logic because the validation should probably exist in a higher abstraction than the parser.

@kevinbgreene do you think I should keep the old tests skipped or remove them?